### PR TITLE
Update Nightcode URL

### DIFF
--- a/nightcode.md
+++ b/nightcode.md
@@ -47,4 +47,4 @@ Try out some of the other buttons on your own and see what they do. "Stop" will 
 
 With that, you are ready to create new Clojure projects in Nightcode!  Good luck, and enjoy Clojuring!
 
-[Nightcode]: https://nightcode.info/
+[Nightcode]: https://sekao.net/nightcode/


### PR DESCRIPTION
I think Zach changed the main page URL. nightcode.info looks down to me, and https://sekao.net/nightcode/ looks like a suitable replacement.
